### PR TITLE
Stop using intent for registering BNFcommands (Task HMT-3654)

### DIFF
--- a/hmt1developerexamples/src/main/res/layout/bnf_activity.xml
+++ b/hmt1developerexamples/src/main/res/layout/bnf_activity.xml
@@ -4,12 +4,8 @@
     android:layout_height="match_parent"
     android:contentDescription="hf_no_number">
 
-    <View
-        android:id="@+id/bnf_view"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
-
     <TextView
+        android:id="@+id/bnfDescription"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerHorizontal="true"


### PR DESCRIPTION
We no longer support registering BNF commands via an intent as WearHF has timing issues when this is done. Using an intent often leads to the voice commands being lost.
Instead WearML directives should be used.

This changeset updates the BNF example to stop using intents