### PR TITLE
Update camera example to show all capture types (Bug HMT-5460)

### DIFF
--- a/hmt1developerexamples/build.gradle
+++ b/hmt1developerexamples/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     defaultConfig {
         applicationId "com.realwear.hmt1developerexamples"
         minSdkVersion 23
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 130
         versionName "1.3.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/hmt1developerexamples/src/main/java/com/realwear/hmt1developerexamples/CameraActivity.java
+++ b/hmt1developerexamples/src/main/java/com/realwear/hmt1developerexamples/CameraActivity.java
@@ -1,43 +1,57 @@
-/**
- * RealWear Development Software, Source Code and Object Code
+/*
+ * RealWear Development Software, Source Code and Object Code.
  * (c) RealWear, Inc. All rights reserved.
- * <p>
+ *
  * Contact info@realwear.com for further information about the use of this code.
  */
 
 package com.realwear.hmt1developerexamples;
 
 import android.app.Activity;
+import android.content.ContentValues;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
 import android.provider.MediaStore;
-import androidx.core.content.FileProvider;
+
+import android.util.Log;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.ImageView;
 
-import java.io.File;
 import java.util.UUID;
 
 import static android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION;
 
 /**
- * Activity that shows how to use the camera to take a picture on a HMT-1 device
+ * Activity that shows how to use the camera to take a pictures and record videos on a HMT-1 device.
  */
 public class CameraActivity extends Activity {
+    private static final String TAG = "CameraActivity";
 
-    // Request code identifying camera events
-    private static final int BASIC_CAMERA_REQUEST_CODE = 1889;
-    private static final int FILEPROVIDER_CAMERA_REQUEST_CODE = 1998;
+    // Request code for playing back videos.
+    private static final int FILE_PLAYBACK_REQUEST_CODE = 5;
+
+    //
+    // Request codes for identifying camera events.
+    //
+    private static final int BITMAP_PHOTO_REQUEST_CODE = 1;
+    private static final int FILE_PROVIDER_PHOTO_REQUEST_CODE = 2;
+    private static final int BASIC_VIDEO_REQUEST_CODE = 3;
+    private static final int FILE_PROVIDER_VIDEO_REQUEST_CODE = 4;
+
+    //
+    // Locations for store content provided images and videos.
+    //
+    private static final String DEFAULT_IMAGE_LOCATION = Environment.DIRECTORY_DCIM + "/Camera";
+    private static final String DEFAULT_VIDEO_LOCATION = Environment.DIRECTORY_MOVIES + "/Camera";
 
     // Identifier for the image returned by the camera
     private static final String EXTRA_RESULT = "data";
 
     private ImageView mImageView;
-    private Uri contentUri;
 
     /**
      * Called when the activity is created
@@ -53,66 +67,107 @@ public class CameraActivity extends Activity {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.camera_main);
 
-        mImageView = (ImageView) findViewById(R.id.camera_image_view);
+        mImageView = findViewById(R.id.camera_image_view);
     }
 
     /**
-     * Listener for when the basic camera button is clicked
+     * Listener for when the bitmap photo button is clicked.
      *
-     * @param view The launch camera button
+     * @param view The button.
      */
-    public void onLaunchCameraBasic(View view) {
-        Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE); // OR ACTION_VIDEO_CAPTURE
-        startActivityForResult(intent, BASIC_CAMERA_REQUEST_CODE);
+    public void onLaunchBitmapPhoto(View view) {
+        final Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+        startActivityForResult(intent, BITMAP_PHOTO_REQUEST_CODE);
     }
 
     /**
-     * Listener for when the FileProvider camera button is clicked
+     * Listener for when the file provider photo button is clicked.
      *
-     * @param view The FileProvider camera button
+     * @param view The button.
      */
-    public void onLaunchCameraFileProvider(View view) {
+    public void onLaunchFileProviderPhoto(View view) {
+        final String fileName = "devexamples-" + UUID.randomUUID() + ".jpg";
 
-            final File mediaStorageDir = getExternalFilesDir(Environment.DIRECTORY_DCIM);
+        final ContentValues contentValues = new ContentValues();
+        contentValues.put(MediaStore.MediaColumns.DISPLAY_NAME, fileName);
+        contentValues.put(MediaStore.MediaColumns.MIME_TYPE, "image/jpg");
+        contentValues.put(MediaStore.MediaColumns.RELATIVE_PATH, DEFAULT_IMAGE_LOCATION);
 
-            final File file = new File(mediaStorageDir, "devexamples-" + UUID.randomUUID() + ".jpg");
+        final Uri contentUri = getBaseContext().getContentResolver().insert(
+                MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues);
 
-            contentUri = FileProvider.getUriForFile(
-                    getApplicationContext(),
-                    getApplicationContext().getPackageName() + ".fileprovider",
-                    file);
+        final Intent captureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+        captureIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        captureIntent.putExtra(MediaStore.EXTRA_OUTPUT, contentUri);
 
-            final Intent captureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE); // OR ACTION_VIDEO_CAPTURE
-            captureIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-            captureIntent.putExtra(MediaStore.EXTRA_OUTPUT, contentUri);
+        startActivityForResult(captureIntent, FILE_PROVIDER_PHOTO_REQUEST_CODE);
+    }
 
-            startActivityForResult(captureIntent, FILEPROVIDER_CAMERA_REQUEST_CODE);
+    /**
+     * Listener for when the bitmap photo button is clicked.
+     *
+     * @param view The button.
+     */
+    public void onLaunchBasicVideo(View view) {
+        final Intent intent = new Intent(MediaStore.ACTION_VIDEO_CAPTURE);
+        startActivityForResult(intent, BASIC_VIDEO_REQUEST_CODE);
+    }
+
+    /**
+     * Listener for when the file provider video button is clicked.
+     *
+     * @param view The button.
+     */
+    public void onLaunchFileProviderVideo(View view) {
+        final String fileName = "devexamples-" + UUID.randomUUID() + ".mp4";
+
+        final ContentValues contentValues = new ContentValues();
+        contentValues.put(MediaStore.MediaColumns.DISPLAY_NAME, fileName);
+        contentValues.put(MediaStore.MediaColumns.MIME_TYPE, "video/mp4");
+        contentValues.put(MediaStore.MediaColumns.RELATIVE_PATH, DEFAULT_VIDEO_LOCATION);
+
+        final Uri contentUri = getBaseContext().getContentResolver().insert(
+                MediaStore.Video.Media.EXTERNAL_CONTENT_URI, contentValues);
+
+        final Intent captureIntent = new Intent(MediaStore.ACTION_VIDEO_CAPTURE);
+        captureIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        captureIntent.putExtra(MediaStore.EXTRA_OUTPUT, contentUri);
+
+        startActivityForResult(captureIntent, FILE_PROVIDER_VIDEO_REQUEST_CODE);
     }
 
     /**
      * Listener for result from external activities. Receives image data from camera.
      *
-     * @param requestCode See Android docs
-     * @param resultCode  See Android docs
-     * @param data        See Android docs
+     * @param requestCode See Android docs.
+     * @param resultCode  See Android docs.
+     * @param data        See Android docs.
      */
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (resultCode == Activity.RESULT_OK && data != null) {
-            switch(requestCode) {
-                case BASIC_CAMERA_REQUEST_CODE: // Display Bitmap received from Camera
-                    Bitmap photo = data.getExtras().getParcelable(EXTRA_RESULT);
+            switch (requestCode) {
+                case BITMAP_PHOTO_REQUEST_CODE:
+                    final Bitmap photo = data.getExtras().getParcelable(EXTRA_RESULT);
                     mImageView.setImageBitmap(photo);
                     break;
 
-                case FILEPROVIDER_CAMERA_REQUEST_CODE: // View saved file in DocumentViewer
+                case FILE_PROVIDER_PHOTO_REQUEST_CODE:
+                    final Uri photoUri = data.getData();
+                    mImageView.setImageURI(photoUri);
+                    break;
 
-                    Intent intent = new Intent();
-                    intent.setAction(Intent.ACTION_VIEW);
-                    intent.addFlags(FLAG_GRANT_READ_URI_PERMISSION);
-                    intent.setDataAndType(contentUri, "image/*");
-                    intent.putExtra("zoom","2");
+                case BASIC_VIDEO_REQUEST_CODE:
+                case FILE_PROVIDER_VIDEO_REQUEST_CODE:
+                    final Uri videoUri = data.getData();
 
-                    startActivityForResult(intent, 1234);
+                    final Intent basicVideoPlayIntent = new Intent();
+                    basicVideoPlayIntent.setAction(Intent.ACTION_VIEW);
+                    basicVideoPlayIntent.addFlags(FLAG_GRANT_READ_URI_PERMISSION);
+                    basicVideoPlayIntent.setDataAndType(videoUri, "video/*");
+                    startActivityForResult(basicVideoPlayIntent, FILE_PLAYBACK_REQUEST_CODE);
+                    break;
+                default:
+                    Log.e(TAG, "Unknown request code: " + requestCode);
                     break;
             }
         }

--- a/hmt1developerexamples/src/main/res/layout/camera_main.xml
+++ b/hmt1developerexamples/src/main/res/layout/camera_main.xml
@@ -36,9 +36,7 @@
             android:layout_centerHorizontal="true"
             android:onClick="onLaunchBitmapPhoto"
             android:text="@string/camera_button_bitmap_photo"
-            android:textSize="18sp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/fpBtn" />
+            android:textSize="18sp" />
 
         <Button
             android:id="@+id/fileProviderPhoto"
@@ -48,9 +46,7 @@
             android:layout_toEndOf="@id/bitmapPhoto"
             android:onClick="onLaunchFileProviderPhoto"
             android:text="@string/camera_button_file_provider_photo"
-            android:textSize="18sp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/basicBtn" />
+            android:textSize="18sp" />
 
     </LinearLayout>
 
@@ -71,9 +67,7 @@
             android:layout_centerHorizontal="true"
             android:onClick="onLaunchBasicVideo"
             android:text="@string/camera_button_basic_video"
-            android:textSize="18sp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/fpBtn" />
+            android:textSize="18sp" />
 
         <Button
             android:id="@+id/fileProviderVideo"
@@ -83,9 +77,7 @@
             android:layout_toEndOf="@id/basicVideo"
             android:onClick="onLaunchFileProviderVideo"
             android:text="@string/camera_button_file_provider_video"
-            android:textSize="18sp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/basicBtn" />
+            android:textSize="18sp" />
 
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/hmt1developerexamples/src/main/res/layout/camera_main.xml
+++ b/hmt1developerexamples/src/main/res/layout/camera_main.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:contentDescription="hf_no_number">
-
 
     <ImageView
         android:id="@+id/camera_image_view"
@@ -21,45 +19,73 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-
     <LinearLayout
+        android:id="@+id/photoButtons"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/videoButtons"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent">
 
-
         <Button
-            android:id="@+id/basicBtn"
+            android:id="@+id/bitmapPhoto"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentBottom="true"
             android:layout_centerHorizontal="true"
-            android:layout_marginEnd="32dp"
-            android:layout_marginBottom="32dp"
-            android:onClick="onLaunchCameraBasic"
-            android:text="@string/camera_button_label_basic"
+            android:onClick="onLaunchBitmapPhoto"
+            android:text="@string/camera_button_bitmap_photo"
             android:textSize="18sp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/fpBtn" />
 
         <Button
-            android:id="@+id/fpBtn"
+            android:id="@+id/fileProviderPhoto"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentBottom="true"
-            android:layout_marginStart="32dp"
-            android:layout_marginBottom="32dp"
-            android:layout_toEndOf="@id/basicBtn"
-            android:onClick="onLaunchCameraFileProvider"
-            android:text="@string/camera_button_label_fileprovider"
+            android:layout_toEndOf="@id/bitmapPhoto"
+            android:onClick="onLaunchFileProviderPhoto"
+            android:text="@string/camera_button_file_provider_photo"
             android:textSize="18sp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toEndOf="@+id/basicBtn" />
 
     </LinearLayout>
 
+    <LinearLayout
+        android:id="@+id/videoButtons"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <Button
+            android:id="@+id/basicVideo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:layout_centerHorizontal="true"
+            android:onClick="onLaunchBasicVideo"
+            android:text="@string/camera_button_basic_video"
+            android:textSize="18sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/fpBtn" />
+
+        <Button
+            android:id="@+id/fileProviderVideo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:layout_toEndOf="@id/basicVideo"
+            android:onClick="onLaunchFileProviderVideo"
+            android:text="@string/camera_button_file_provider_video"
+            android:textSize="18sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/basicBtn" />
+
+    </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/hmt1developerexamples/src/main/res/values/strings.xml
+++ b/hmt1developerexamples/src/main/res/values/strings.xml
@@ -22,8 +22,10 @@
     <string name="action_button_label">Press the Action Button!</string>
 
     <!-- Resources for Camera Activity -->
-    <string name="camera_button_label_basic">Bitmap Camera</string>
-    <string name="camera_button_label_fileprovider">File Provider Camera</string>
+    <string name="camera_button_bitmap_photo">Bitmap Photo</string>
+    <string name="camera_button_file_provider_photo">File Provider Photo</string>
+    <string name="camera_button_basic_video">Basic Video</string>
+    <string name="camera_button_file_provider_video">File Provider Video</string>
 
     <!-- Resources for Document Activity -->
     <string name="document_button_label">Launch Document Viewer</string>


### PR DESCRIPTION
Updated the camera example to show how to capture:
* Photos where the camera returns a bitmap
* Photos when the app passes a content provided URI to the camera to write the file to
* Videos where the camera creates the file and passes it back to the calling app
* Videos where the calling app creates the file and passes it to the camera to write the video to