### PR TITLE
Fixed audio record example for Android 10 (Bug HMT-5486)

### DIFF
--- a/hmt1developerexamples/src/main/AndroidManifest.xml
+++ b/hmt1developerexamples/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.realwear.hmt1developerexamples">
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"></uses-permission>
     <uses-permission android:name="android.permission.RECORD_AUDIO"></uses-permission>
 
     <application


### PR DESCRIPTION
Fixed an issue where the audio example failed to create the file in /sdcard/music as this is blocked in Android 10
We now use scoped storage, which also means we no longer need the WRITE_EXTERNAL_STORAGE permission